### PR TITLE
Yocto Fido build is broken for recipe go-cross.

### DIFF
--- a/recipes-devtools/go/go-cross_1.5.1.bb
+++ b/recipes-devtools/go/go-cross_1.5.1.bb
@@ -3,7 +3,8 @@ inherit cross
 require go_${PV}.inc
 
 do_compile() {
-  export GOROOT_BOOTSTRAP="${SYSROOT}${libdir}/go-bootstrap-${GO_BOOTSTRAP_VERSION}"
+  # The compiler used to build the cross version is one directory up from 'libdir'.
+  export GOROOT_BOOTSTRAP="${SYSROOT}${libdir}/../go-bootstrap-${GO_BOOTSTRAP_VERSION}"
 
   ## Setting `$GOBIN` doesn't do any good, looks like it ends up copying binaries there.
   export GOROOT_FINAL="${SYSROOT}${libdir}/go"


### PR DESCRIPTION
The actual v4.1 bootstrap compiler is installed one directory
higher in the actual '/usr/lib' folder.
