### PR TITLE
go: Use nonarch_libdir in native/cross recipes

### DIFF
--- a/recipes-devtools/go/go-1.5.4/do_not_create_native_cross_compilation_tools.patch
+++ b/recipes-devtools/go/go-1.5.4/do_not_create_native_cross_compilation_tools.patch
@@ -1,0 +1,14 @@
+diff -ruN go.orig/src/make.bash go/src/make.bash
+--- go.orig/src/make.bash	2016-01-19 09:55:32.626423144 +0100
++++ go/src/make.bash		2016-01-19 10:23:06.630374784 +0100
+@@ -157,10 +157,6 @@
+ 	echo
+ fi
+ 
+-echo "##### Building packages and commands for $GOOS/$GOARCH."
+-CC="$CC_FOR_TARGET" "$GOTOOLDIR"/go_bootstrap install $GO_FLAGS -gcflags "$GO_GCFLAGS" -ldflags "$GO_LDFLAGS" -x -v std cmd
+-echo
+-
+ rm -f "$GOTOOLDIR"/go_bootstrap
+ 
+ if [ "$1" != "--no-banner" ]; then

--- a/recipes-devtools/go/go-bootstrap_1.4.3.bb
+++ b/recipes-devtools/go/go-bootstrap_1.4.3.bb
@@ -4,7 +4,7 @@ inherit native
 
 do_compile() {
   ## Setting `$GOBIN` doesn't do any good, looks like it ends up copying binaries there.
-  export GOROOT_FINAL="${GOROOT_BOOTSTRAP}"
+  export GOROOT_FINAL="${SYSROOT}${nonarch_libdir}/${PN}-${PV}"
 
   setup_go_arch
 

--- a/recipes-devtools/go/go_1.5.4.inc
+++ b/recipes-devtools/go/go_1.5.4.inc
@@ -9,4 +9,5 @@ SRC_URI[go_1_5.sha256sum] = "002acabce7ddc140d0d55891f9d4fcfbdd806b9332fb8b110c9
 SRC_URI += "\
         file://Fix-ccache-compilation-issue.patch \
         file://fix-cross-compilation.patch \
+        file://do_not_create_native_cross_compilation_tools.patch \
         "

--- a/recipes-devtools/go/go_1.6.2.inc
+++ b/recipes-devtools/go/go_1.6.2.inc
@@ -9,4 +9,5 @@ SRC_URI[go_1_6.sha256sum] = "787b0b750d037016a30c6ed05a8a70a91b2e9db4bd9b1a2453a
 SRC_URI += "\
         file://Fix-ccache-compilation-issue.patch \
         file://fix-cross-compilation.patch \
+        file://do_not_create_native_cross_compilation_tools.patch \
         "


### PR DESCRIPTION
Add a patch to remove creation of cross/native
tools

Signed-off-by: Khem Raj raj.khem@gmail.com
