### PR TITLE
go.bbclass: remove quilt patches and state dirs during install

### DIFF
--- a/classes/go.bbclass
+++ b/classes/go.bbclass
@@ -39,7 +39,9 @@ do_go_install() {
 		-name \*.indirectionsymlink -o \
 		-name .git\* -o                \
 		-name .hg -o                   \
-		-name .svn                     \
+		-name .svn -o                  \
+		-name .pc\* -o                 \
+		-name patches\*                \
 		\) -print0 | \
 	xargs -r0 rm -rf
 


### PR DESCRIPTION
Directories  `patches` and `.pc`, created when applying patches with quilt, are left over by `do_go_install`.
