### PR TITLE
Fix cgo toolchain path error when on target platform.

### DIFF
--- a/recipes-devtools/go/go.inc
+++ b/recipes-devtools/go/go.inc
@@ -52,12 +52,15 @@ setup_go_arch() {
 }
 
 setup_cgo_gcc_wrapper() {
+  sdkpathnative=${7:-${SDKPATHNATIVE}}
+  bindir=${5:-${bindir_nativesdk}}
+
   # Is there a bug in the cross-compiler support for CGO? Can't get it
   # to work without this wrapper
   for t in gcc g++ ; do
     cat > ${WORKDIR}/${TARGET_PREFIX}${t} <<EOT
 #!/bin/sh
-exec ${TARGET_PREFIX}${t} ${TARGET_CC_ARCH} --sysroot=${STAGING_DIR_TARGET} "\$@"
+exec ${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}${t} ${TARGET_CC_ARCH} --sysroot=${STAGING_DIR_TARGET} "\$@"
 EOT
     chmod +x ${WORKDIR}/${TARGET_PREFIX}${t}
   done

--- a/recipes-devtools/go/go_1.6.3.bb
+++ b/recipes-devtools/go/go_1.6.3.bb
@@ -51,7 +51,7 @@ go_install() {
   for t in gcc g++ ; do
     cat > ${D}${GOROOT_FINAL}/bin/${TARGET_PREFIX}${t} <<EOT
 #!/bin/sh
-exec {TARGET_PREFIX}${t} ${TARGET_CC_ARCH} --sysroot=${STAGING_DIR_TARGET} "\$@"
+exec ${TARGET_PREFIX}${t} ${TARGET_CC_ARCH} --sysroot=${STAGING_DIR_TARGET} "\$@"
 EOT
     chmod +x ${D}${GOROOT_FINAL}/bin/${TARGET_PREFIX}${t}
   done

--- a/recipes-devtools/go/go_1.6.3.bb
+++ b/recipes-devtools/go/go_1.6.3.bb
@@ -1,5 +1,7 @@
 require go_${PV}.inc
 
+PR = "r5"
+
 PN_class-native = "go-native"
 PN_class-cross = "go-cross"
 
@@ -18,11 +20,13 @@ do_compile() {
 
   setup_cgo_gcc_wrapper
 
+  ## Add WORKDIR to path.
+  export PATH="${WORKDIR}/:$PATH"
   ## TODO: consider setting GO_EXTLINK_ENABLED
   export CGO_ENABLED="${GO_CROSS_CGO_ENABLED}"
   export CC=${BUILD_CC}
-  export CC_FOR_TARGET="${WORKDIR}/${TARGET_PREFIX}gcc"
-  export CXX_FOR_TARGET="${WORKDIR}/${TARGET_PREFIX}g++"
+  export CC_FOR_TARGET="${TARGET_PREFIX}gcc"
+  export CXX_FOR_TARGET="${TARGET_PREFIX}g++"
   export GO_GCFLAGS="${HOST_CFLAGS}"
   export GO_LDFLAGS="${HOST_LDFLAGS}"
 
@@ -34,6 +38,7 @@ do_compile() {
 }
 
 go_install() {
+  
   install -d "${D}${bindir}" "${D}${GOROOT_FINAL}"
   tar -C "${WORKDIR}/go-${PV}/go" -cf - bin lib src pkg test |
   tar -C "${D}${GOROOT_FINAL}" -xf -
@@ -46,7 +51,7 @@ go_install() {
   for t in gcc g++ ; do
     cat > ${D}${GOROOT_FINAL}/bin/${TARGET_PREFIX}${t} <<EOT
 #!/bin/sh
-exec ${TARGET_PREFIX}${t} ${TARGET_CC_ARCH} --sysroot=${STAGING_DIR_TARGET} "\$@"
+exec {TARGET_PREFIX}${t} ${TARGET_CC_ARCH} --sysroot=${STAGING_DIR_TARGET} "\$@"
 EOT
     chmod +x ${D}${GOROOT_FINAL}/bin/${TARGET_PREFIX}${t}
   done


### PR DESCRIPTION
The path to the gcc and g++ compilers had the yocto build system's
paths rather than a target system path baked into the tools.
This caused broken builds for native code on the target device.
The compile task for the recipe added the package's workspace to
PATH and used explicit paths to the compilers in the batch files
that wrapped access to the tools.