### PR TITLE
cloud.google.com-go: Add missing dep on golang.org-x-text

### DIFF
--- a/recipes-net/cloud.google.com-go/cloud.google.com-go.bb
+++ b/recipes-net/cloud.google.com-go/cloud.google.com-go.bb
@@ -5,6 +5,8 @@ LICENSE = "MIT"
 
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
+DEPENDS += "golang.org-x-text"
+
 GO_IMPORT = "cloud.google.com/go"
 GO_INSTALL = "\
 	cloud.google.com/go/compute/metadata \


### PR DESCRIPTION
Fixes errors e.g.

| src/cloud.google.com/go/compute/metadata/metadata.go:35:2: cannot find package "golang.org/x/net/context" in a
ny of:

Signed-off-by: Khem Raj <raj.khem@gmail.com>