### PR TITLE
Add LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -13,3 +13,6 @@ BBFILE_PRIORITY_go = "1"
 LAYERVERSION_skeleton = "1"
 
 LAYERDEPENDS_skeleton = "core"
+
+# Yocto Project Compatible version 2 standard requires setting it
+LAYERSERIES_COMPAT_go = "pyro rocko sumo"


### PR DESCRIPTION
I've tried compiling with `sumo` version of everything and `bitbake` at 1.38 and it throws a warning that this variable [has to be defined](https://www.yoctoproject.org/docs/2.6/ref-manual/ref-manual.html#var-LAYERSERIES_COMPAT). I've only included `pyro` because we started with it and `sumo` because it's what I'm upgrading to and `rocko` because in between, you may want to add others.